### PR TITLE
[HOTFIX!]: 더 이상 사용되지 않는 Actions 변경

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -317,7 +317,7 @@ jobs:
       uses: actions/checkout@v4
     
     - name: Docker 이미지 아티팩트 다운로드
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: docker-images
         path: ./server/


### PR DESCRIPTION
## 작업 내용

- `actions/download-artifact@v3`이 Deprecated됨에 따라 v4로 업데이트